### PR TITLE
feat: Implement Terraform state management with S3 bucket only and remove DynamoDB from backend config

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -59,11 +59,10 @@ runs:
       uses: hashicorp/setup-terraform@v3
 
     - name: Compute Backend Key from Repository Name
-      id: tf-state-key
+      id: key
       shell: bash
       working-directory: ${{ github.workspace }}/${{ inputs.terraform-dir }}
       run: |
-
         if [[ "${{ inputs.ci-pipeline }}" == "true" ]]; then
           state_key="${{ github.repository }}/${{ github.sha }}/terraform.tfstate"
         else
@@ -81,7 +80,7 @@ runs:
           -backend-config="key=${{ steps.key.outputs.s3_key }}" \
           -backend-config="region=${{ inputs.s3-region }}" \
           -backend-config="encrypt=true" \
-          -backend-config="use_lockfile=true"
+          -backend-config="dynamodb_table=${{ inputs.dynamodb-table }}"
 
     - name: Terraform Plan and Save Output
       id: tf-plan

--- a/action.yaml
+++ b/action.yaml
@@ -3,7 +3,7 @@ description: "Run terraform plan with support for S3 backend and artifact upload
 
 
 inputs:
-  release_tag:
+  release-tag:
     description: 'Optional release tag to checkout'
     required: false
     type: string
@@ -14,11 +14,6 @@ inputs:
     required: false
     default: "tf"
 
-  tf-vars-file:
-    description: "Optional Terraform variable file"
-    required: false
-    default: "terraform.tfvars"
-
   s3-bucket:
     description: "S3 bucket for Terraform backend"
     required: true
@@ -26,6 +21,21 @@ inputs:
   s3-region:
     description: "AWS region where the S3 bucket is located"
     required: true
+
+  tf-plan-file:
+    description: "File to save the Terraform plan output"
+    required: false
+    default: "tfplan"  
+
+  tf-vars-file:
+    description: "Optional Terraform variable file"
+    required: false
+    default: "terraform.tfvars"
+
+  tf-plan-name:
+    description: "Name of the Terraform plan file"
+    required: false
+    default: "terraform-plan"
 
   ci-pipeline:
     description: "Set to true to use commit SHA in backend key"
@@ -49,8 +59,11 @@ runs:
       uses: hashicorp/setup-terraform@v3
 
     - name: Compute Backend Key from Repository Name
-      id: key
+      id: tf-state-key
+      shell: bash
+      working-directory: ${{ github.workspace }}/${{ inputs.terraform-dir }}
       run: |
+
         if [[ "${{ inputs.ci-pipeline }}" == "true" ]]; then
           state_key="${{ github.repository }}/${{ github.sha }}/terraform.tfstate"
         else
@@ -60,6 +73,9 @@ runs:
       shell: bash
 
     - name: Terraform Init with S3 Backend
+      id: tf-init
+      shell: bash
+      working-directory: ${{ github.workspace }}/${{ inputs.terraform-dir }}
       run: |
         terraform init -input=false \
           -backend-config="bucket=${{ inputs.s3-bucket }}" \
@@ -67,27 +83,25 @@ runs:
           -backend-config="region=${{ inputs.s3-region }}" \
           -backend-config="encrypt=true" \
           -backend-config="use_lockfile=true"
-      shell: bash
-      working-directory: ${{ github.workspace }}/${{ inputs.terraform-dir }}
 
     - name: Terraform Plan and Save Output
-      id: plan
-      run: |
-        PLAN_FILE=tfplan
-        echo "### Terraform Plan" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-        terraform plan -input=false -out=${PLAN_FILE}.out -var-file=${{ inputs.tf-vars-file }}
-        terraform show -no-color ${PLAN_FILE}.out > ${PLAN_FILE}.txt
-        echo "\`\`\`hcl" >> $GITHUB_STEP_SUMMARY
-        cat ${PLAN_FILE}.txt >> $GITHUB_STEP_SUMMARY
-        echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+      id: tf-plan
       shell: bash
       working-directory: ${{ github.workspace }}/${{ inputs.terraform-dir }}
+      run: |
+        echo "### Terraform Plan" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        terraform plan -input=false -out=${{ inputs.tf-plan-file }}.out -var-file=${{ inputs.tf-vars-file }}
+        terraform show -no-color ${{ inputs.tf-plan-file }}.out > ${{ inputs.tf-plan-file }}.txt
+        echo "\`\`\`hcl" >> $GITHUB_STEP_SUMMARY
+        cat ${{ inputs.tf-plan-file }}.txt >> $GITHUB_STEP_SUMMARY
+        echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+
 
     - name: Upload Plan Output as Artifact
       uses: actions/upload-artifact@v4
       with:
-        name: terraform-plan
+        name: ${{ inputs.tf-plan-name }}
         path: |
-          ${{ github.workspace }}/${{ inputs.terraform-dir }}/tfplan.out
+          ${{ github.workspace }}/${{ inputs.terraform-dir }}/${{ inputs.tf-plan-file }}.out
 

--- a/action.yaml
+++ b/action.yaml
@@ -3,6 +3,12 @@ description: "Run terraform plan with support for S3 backend and artifact upload
 
 
 inputs:
+  release_tag:
+    description: 'Optional release tag to checkout'
+    required: false
+    type: string
+    default: ''
+
   terraform-dir:
     description: "Path to the Terraform configuration"
     required: false
@@ -21,10 +27,6 @@ inputs:
     description: "AWS region where the S3 bucket is located"
     required: true
 
-  dynamodb-table:
-    description: "DynamoDB table name for state locking"
-    required: true
-
   ci-pipeline:
     description: "Set to true to use commit SHA in backend key"
     required: false
@@ -40,6 +42,8 @@ runs:
   steps:
     - name: Checkout repository
       uses: actions/checkout@v4
+      with:
+          ref: ${{ inputs.release_tag || github.ref_name }} 
 
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@v3
@@ -62,7 +66,7 @@ runs:
           -backend-config="key=${{ steps.key.outputs.s3_key }}" \
           -backend-config="region=${{ inputs.s3-region }}" \
           -backend-config="encrypt=true" \
-          -backend-config="dynamodb_table=${{ inputs.dynamodb-table }}"
+          -backend-config="use_lockfile=true"
       shell: bash
       working-directory: ${{ github.workspace }}/${{ inputs.terraform-dir }}
 

--- a/action.yaml
+++ b/action.yaml
@@ -70,7 +70,6 @@ runs:
           state_key="${{ github.repository }}/terraform.tfstate"
         fi
         echo "s3_key=$state_key" >> $GITHUB_OUTPUT
-      shell: bash
 
     - name: Terraform Init with S3 Backend
       id: tf-init


### PR DESCRIPTION
This pull request updates the `action.yaml` file to enhance flexibility and configurability for running Terraform workflows. Key changes include the addition of new input parameters, reorganization of existing inputs, and updates to the steps for better customization and artifact handling.

### Enhancements to Input Parameters:
* Added a new optional `release-tag` input to allow checking out a specific release tag.
* Introduced `tf-plan-file` and `tf-plan-name` inputs to customize the Terraform plan output file and artifact name, respectively.
* Re-added `tf-vars-file` input, which was temporarily removed, to specify an optional Terraform variable file.

### Improvements to Workflow Steps:
* Updated the repository checkout step to use the new `release-tag` input if provided, falling back to the default branch reference.
* Enhanced the Terraform initialization and plan steps to use the new customizable `tf-plan-file` input, improving flexibility in file naming.
* Modified the artifact upload step to use the `tf-plan-name` input for naming the uploaded Terraform plan artifact.