### PR TITLE
chore: add CodeQL advanced setup workflow

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,0 +1,42 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "21 6 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [actions, javascript-typescript]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-and-quality
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Problem

The repo currently uses GitHub's **default** CodeQL setup. That means action versions, query suite, and language matrix are controlled by the GitHub UI rather than in-repo, and the April 2026 CodeQL Action file-coverage warning is surfaced without us having visibility into the exact version running.

## Fix

Add `.github/workflows/codeql.yaml` implementing advanced setup:

- Triggers: push to `main`, PRs to `main`, weekly cron.
- Languages: `actions` (for workflow/action YAML analysis) and `javascript-typescript` (for `scripts/plugins/*.js` semantic-release plugins).
- Query suite: `security-and-quality`.
- Action versions pinned via major tags (`@v3` for `github/codeql-action`, `@v6` for `actions/checkout`) — Dependabot (already configured) will bump these.

## Required follow-up in repo settings

After this PR merges, **disable default CodeQL setup** at `Settings → Code security → Code scanning → Default setup → Disable`. Otherwise the two setups conflict and default setup will take precedence.

## Note on the original warning

> Starting April 2026, the CodeQL Action will skip computing file coverage information on pull requests…

This is an upstream announcement from the CodeQL Action itself and cannot be silenced by any configuration. Advanced setup does not change this. The benefit of this PR is only visibility/pinning, not silencing that specific warning.

## Test plan

- [ ] Merge PR and disable default setup in repo settings.
- [ ] Verify the `CodeQL / Analyze (actions)` and `CodeQL / Analyze (javascript-typescript)` jobs run on the next PR and complete successfully.
- [ ] Confirm results appear under Security → Code scanning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)